### PR TITLE
bump Pillow version. Remove sphinx from user dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-Pillow==4.2.1
-Sphinx==1.6.3
-sphinxcontrib-websupport==1.0.1
+Pillow>=9.0.0


### PR DESCRIPTION
sphinx should be developer dependencies and not listed in `requirements.txt`. We should move to `pyproject.toml`. Later.

I bumped pillow which was highly outdated. That was the main reason for the failing tests in the pipeline.