### PR TITLE
Load: Ensure single byte strings (GPS LatitudeRef and LongitudeRef) can be decoded and re-encoded properly

### DIFF
--- a/piexif/_load.py
+++ b/piexif/_load.py
@@ -164,6 +164,8 @@ class _ExifReader(object):
             if length > 4:
                 pointer = struct.unpack(self.endian_mark + "L", value)[0]
                 data = self.tiftag[pointer : pointer + length - 1]
+            elif length == 1:
+                data = value[0:length]
             else:
                 data = value[0 : length - 1]
         elif t == TYPES.Short:  # SHORT


### PR DESCRIPTION
Hi @davetapley ,
From what I've read this is the official repo for `piexif`? See: https://pypi.org/project/piexif/

Reading the EXIF tags from an image appears to be corrupting the `GPSLatitudeRef` and `GPSLongitudeRef` fields in the EXIF data. Writing this data back to their fields is resulting in some applications unable to process the geotag in the images.